### PR TITLE
Use external PostgreSQL server as the backend database

### DIFF
--- a/xnat-jupyterhub-chart/templates/service.yaml
+++ b/xnat-jupyterhub-chart/templates/service.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.postgresql.enabled }}
+{{- else }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-postgresql
+  labels:
+    {{- include "jupyterhub.commonLabels" . | nindent 4 }}
+spec:
+{{- if .Values.postgresqlExternalName }}
+  type: ExternalName
+  externalName: {{ .Values.postgresqlExternalHost}}
+{{- else }}
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - port: 5432
+      targetPort: 5432
+      protocol: TCP
+      name: postgresql
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: {{ .Release.Name }}-postgresql
+  labels:
+    {{- include "jupyterhub.commonLabels" . | nindent 4 }}
+subsets:
+  - addresses:
+      {{- range .Values.postgresqlExternalIPs }}
+      - ip: {{ . | quote }}
+      {{- end }}
+    ports:
+      - port: 5432
+{{- end }}
+{{- end }}

--- a/xnat-jupyterhub-chart/templates/service.yaml
+++ b/xnat-jupyterhub-chart/templates/service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.postgresql.enabled }}
+{{- if and (.Values.postgresql.enabled) (eq .Values.jupyterhub.hub.db.type "postgresql")}}
 {{- else }}
 apiVersion: v1
 kind: Service
@@ -7,7 +7,7 @@ metadata:
   labels:
     {{- include "jupyterhub.commonLabels" . | nindent 4 }}
 spec:
-{{- if .Values.postgresqlExternalName }}
+{{- if .Values.postgresqlExternalHost }}
   type: ExternalName
   externalName: {{ .Values.postgresqlExternalHost}}
 {{- else }}

--- a/xnat-jupyterhub-chart/values.yaml
+++ b/xnat-jupyterhub-chart/values.yaml
@@ -8,6 +8,10 @@ postgresql:
   enabled: true
   persistence:
     size: 1Gi
+    
+# Use either external database service alias or endpoint when postgresql.enabled is set to false
+postgresqlExternalHost: ""
+postgresqlExternalIPs: []
 
 jupyterhub:
   enabled: true


### PR DESCRIPTION
Instead of using the internal PostgreSQL from the subchart, allow user to use external PostgreSQL server when 'postgresql.enabled' in supplied custom values.yaml is set to 'false'.