### PR TITLE
match jupyterhub.hub.db.type value with what is in values.yaml

### DIFF
--- a/xnat-jupyterhub-chart/templates/service.yaml
+++ b/xnat-jupyterhub-chart/templates/service.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.postgresql.enabled) (eq .Values.jupyterhub.hub.db.type "postgresql")}}
+{{- if and (.Values.postgresql.enabled) (eq .Values.jupyterhub.hub.db.type "postgres")}}
 {{- else }}
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
To fix the previous typo in service.yaml, so the condition matched the below in values.yaml

```
db:
      type: postgres
```