### PR TITLE
Fix for JHP-119

### DIFF
--- a/xnat-jupyterhub-chart/files/pre_spawn_hook.py
+++ b/xnat-jupyterhub-chart/files/pre_spawn_hook.py
@@ -80,7 +80,7 @@ def pre_spawn_hook(spawner):
                     tgt = m['target']
 
                     # Workspaces mountings are handled by JupyterHub chart
-                    if '/workspaces/' in src:
+                    if '/workspace/' in tgt:
                         continue
 
                     # This presumes that all mounts are within the archive volume, which is not always the case.


### PR DESCRIPTION
Changed `if '/workspaces/' in src:` to `if '/workspace/' in tgt:` to allow any arbitrary workspace path from XNAT to work since the target XNAT is creating will be /workspaces/ even if the source path isn't.